### PR TITLE
Corrected Improper Use of class Attribute to className in React Components

### DIFF
--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,11 +1,11 @@
-import React from 'react'
+
 
 const Experience = () => {
   return (
-    <div class="py-10 bg-[#232325]" id='experience'>
+    <div className="py-10 bg-[#232325]" id='experience'>
         <h2 className='mb-8 text-3xl text-white text-center'>My <span>Experience</span></h2>
 
-        <div class="mb-[20px] text-white bg-gray-700/20 p-4 rounded-3xl max-w-[300px] sm:max-w-[600px] mx-auto">
+        <div className="mb-[20px] text-white bg-gray-700/20 p-4 rounded-3xl max-w-[300px] sm:max-w-[600px] mx-auto">
             <p>First Company</p>
             <p className='text-gray-400'>(2020 - Present)</p>
             <p className='text-gray-500'>
@@ -13,9 +13,9 @@ const Experience = () => {
             </p>
         </div>
 
-        <div class="h-[50px] w-[2px] bg-slate-400 my-1 mx-auto"></div>
+        <div className="h-[50px] w-[2px] bg-slate-400 my-1 mx-auto"></div>
 
-        <div class="mb-[20px] text-white bg-gray-700/20 p-4 rounded-3xl max-w-[300px] sm:max-w-[600px] mx-auto">
+        <div className="mb-[20px] text-white bg-gray-700/20 p-4 rounded-3xl max-w-[300px] sm:max-w-[600px] mx-auto">
             <p>Second Company</p>
             <p className='text-gray-400'>(2020 - Present)</p>
             <p className='text-gray-500'>
@@ -23,9 +23,9 @@ const Experience = () => {
             </p>
         </div>
 
-        <div class="h-[50px] w-[2px] bg-slate-400 my-1 mx-auto"></div>
+        <div className="h-[50px] w-[2px] bg-slate-400 my-1 mx-auto"></div>
 
-        <div class="mb-[20px] text-white bg-gray-700/20 p-4 rounded-3xl max-w-[300px] sm:max-w-[600px] mx-auto">
+        <div className="mb-[20px] text-white bg-gray-700/20 p-4 rounded-3xl max-w-[300px] sm:max-w-[600px] mx-auto">
             <p>Third Company</p>
             <p className='text-gray-400'>(2020 - Present)</p>
             <p className='text-gray-500'>
@@ -33,9 +33,9 @@ const Experience = () => {
             </p>
         </div>
 
-        <div class="h-[50px] w-[2px] bg-slate-400 my-1 mx-auto"></div>
+        <div className="h-[50px] w-[2px] bg-slate-400 my-1 mx-auto"></div>
 
-        <div class="mb-[20px] text-white bg-gray-700/20 p-4 rounded-3xl max-w-[300px] sm:max-w-[600px] mx-auto">
+        <div className="mb-[20px] text-white bg-gray-700/20 p-4 rounded-3xl max-w-[300px] sm:max-w-[600px] mx-auto">
             <p>Fourth Company</p>
             <p className='text-gray-400'>(2020 - Present)</p>
             <p className='text-gray-500'>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -59,7 +59,7 @@ const Hero = () => {
             href="/"
             title="Download CV"
             role="button"
-            class="mt-4 px-4 py-2 text-lg font-bold text-white  bg-primary-color rounded-xl">
+            className="mt-4 px-4 py-2 text-lg font-bold text-white  bg-primary-color rounded-xl">
             Download CV
           </button>
       </div>

--- a/src/components/ShinyEffect.jsx
+++ b/src/components/ShinyEffect.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+
 
 const ShinyEffect = ({left, right, top, size = 500}) => {
 


### PR DESCRIPTION
In some components, class was written instead of className, so I have fixed that issue.